### PR TITLE
Containerize application with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN poetry config virtualenvs.create false
 
 RUN poetry install
 
-CMD poetry run python manage.py --host 0.0.0.0
+ENTRYPOINT ["poetry", "run", "python", "manage.py", "--host", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ RUN git clone https://github.com/geoffrey45/swing-client.git client
 
 WORKDIR /client
 
+RUN git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
+
 RUN yarn install
 
 RUN yarn build

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN poetry config virtualenvs.create false
 
 RUN poetry install
 
-ENTRYPOINT ["poetry", "run", "python", "manage.py", "--host", "0.0.0.0"]
+ENTRYPOINT ["poetry", "run", "python", "manage.py", "--host", "0.0.0.0", "--config", "/config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:latest AS CLIENT
+
+RUN git clone https://github.com/geoffrey45/swing-client.git client
+
+WORKDIR /client
+
+RUN yarn install
+
+RUN yarn build
+
+FROM python:latest
+
+WORKDIR /app/swingmusic
+
+COPY . .
+
+COPY --from=CLIENT /client/dist/ client
+
+EXPOSE 1970/tcp
+
+VOLUME /music
+
+VOLUME /config
+
+RUN pip install poetry
+
+RUN poetry config virtualenvs.create false
+
+RUN poetry install
+
+CMD poetry run python manage.py --host 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -51,6 +51,54 @@ swingmusic --host 0.0.0.0
 
 The link to access the app will be printed on your terminal. Copy it and open it in your browser.
 
+### Docker
+
+You can run Swing in a Docker container. To do so, clone the repository and build the image:
+
+    git clone https://github.com/swing-opensource/swingmusic.git --depth 1
+    docker build . -t swingmusic
+
+Then create the container. Here are some example snippets to help you get started creating a container.
+
+#### docker-compose
+
+```yaml
+---
+version: "3.8"
+services:
+  swing:
+    image: swingmusic
+    container_name: swingmusic
+    volumes:
+      - /path/to/music:/music
+      - /path/to/config:/config
+    ports:
+      - 1970:1970
+    restart: unless-stopped
+```
+
+#### docker cli
+
+```bash
+docker run -d \
+  --name=swingmusic \
+  -p 1970:1970 \
+  -v /path/to/music:/music \
+  -v /path/to/config:/config \
+  --restart unless-stopped \
+  swingmusic
+```
+
+#### Parameters
+
+Container images are configured using parameters passed at runtime (such as those above). These parameters are separated by a colon and indicate `<external>:<internal>` respectively. For example, `-p 8080:80` would expose port `80` from inside the container to be accessible from the host's IP on port `8080` outside the container.
+
+| Parameter | Function |
+| :----: | --- |
+| `-p 1970` | WebUI |
+| `-v /music` | Recommended directory to store your music collection. You can bind other folder if you wish. |
+| `-v /config` | Configuration files. |
+
 ### Development
 
 This project is broken down into 2. The client and the server. The client comprises of the user interface code. This part is written in Typescript, Vue 3 and SCSS. To setup the client, checkout the [swing client repo ](https://github.com/geoffrey45/swing-client) on GitHub.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The link to access the app will be printed on your terminal. Copy it and open it
 You can run Swing in a Docker container. To do so, clone the repository and build the image:
 
     git clone https://github.com/swing-opensource/swingmusic.git --depth 1
+    cd swingmusic
     docker build . -t swingmusic
 
 Then create the container. Here are some example snippets to help you get started creating a container.


### PR DESCRIPTION
I have added a Dockerfile that builds the client from source and runs the server. I saw in other issues that you are still learning about Docker, so I'll explain how it works so it's easier for you to follow. Excuse me if I give too much detail, but I don't know how much you know about Docker, so I'll assume you know very little.

In Docker, you first build images. Images are sort of blueprints. They are static, they can't be used as-is, and they contain all the files that would be stored inside a Docker container. From these images, you create the containers themselves. The Dockerfile contains the instructions to make these images.

Once an image is built, you can create as many containers from it as you wish. These containers can then be modified. Their internal filesystem can be changed, and you can run applications within them. However, since they are separated from the rest of your system, once the container is deleted, anything inside it is lost. In order to persist data, you need to use bind mounts, or volumes.

Bind mounts essentially map a folder in your regular system, to a folder inside the container. Whatever data gets written into the folder, is reflected in both systems. You can then delete and re-create containers as you see fit, and they will pick-up this bind mount and can read their files. A very common thing to use them for is config files. Programs should store all the configurations, databases, or other persistent data in a single folder, which can then be bind mounted. Later, if you update the application, you remove the container, re-create it from an updated image, and it can re-read the bind mount to restore the configuration.

Volumes work similarly, but they are managed by Docker. They also kind of map a folder in your filesystem to one in your container, but you can't choose what the folder in your filesystem is. It's stored in a special directory intended for Docker alone, and they are used for data that you want to persist, but shouldn't be directly handled by the user.

This is something the user chooses how to use tho, the image only states what folder or folders should be binded, but doesn't enforce it.

So, with that out of the way, I'll proceed to explain how this particular Dockerfile works.

You can see that it starts with a `FROM` directive. This means that the Docker image we want to build, will use another, separate image as its base. Since we don't want to install all the dependencies that make the entire operating system, we use one of these base images.

In this case, since your program is split into a client and server, I used a multi-stage build process. I temporarily use the `node` image to build the client, and that gets copied later on to the actual final image.

You can see I run a couple commands with the `RUN` directive, you can guess what they do. `WORKDIR` essentially sets the current directory, like using `cd` on a shell.

We then encounter a second `FROM` directive. This is the base image the final image will be based on (that's a mouthful). We set a `WORKDIR` like before, and we `COPY` everything from the current directory (that would be this repository) into the current directory inside the container (set by `WORKDIR`).

We then also `COPY` from the previous image, which was labeled as `CLIENT` in the very first line. The first path corresponds to the `CLIENT` image, and the second path corresponds to the current (final) image, and is relative to `WORKDIR`.

We then expose the port the program uses. This is the same concept as opening ports on a router. Docker has its own internal networks for each container after all.

I also set some `VOLUME`s. Remember, the user should actually bind folder or volumes to these folders. If they don't, docker creates dummy volumes for them, but this actually works more as documentation than anything else. Of course, these folders aren't actually checked by your program. I couldn't find where it stores config files, or even if they are centralized in a single folder or file. If they don't, ensure they do, and change that line to point to it (remember that the repo is stored in `/app/swingmusic` in the container).

After that I install poetry and the needed dependencies. I disable the virtualenvs option for poetry, since this is running in a container, it's already isolated.

Finally, the `CMD` directive is the command to run when the container starts. I also set the host to `0.0.0.0` so it is broadcasted to the local network, needed if you want to be able to access it from outside the docker container.

So now, if you want to try it out, clone the repository with the Dockerfile, and run:

    docker build . -t swingmusic

If your user is not part of the `docker` group, then you will need to use `sudo`. This assumes you're on Linux of course. If you're not, then I'm afraid you'll have to look somewhere else :P

Anyway, the command will look for a file named `Dockerfile` by default, and will build it. The `-t swingmusic` part sets a tag for the final image, basically a name. It's optional, but setting it makes it easier to work with later on.

Once the image is created, you can see it with:

    docker image ls

There's likely more than one, since more images had to be downloaded to build this one.

You can then create a container from this image like this:

    docker run --name swingmusic -p 1970:1970 swingmusic

This will create a container named `swinmusic`, it will bind the port `1970` in your machine, to the port `1970` inside the container. Without this, you wouldn't be able to access the site. And lastly, at the very end, we specify the name (or tag) of the image we want to use to create this container, `swingmusic` in this case.

I have noticed that after doing this, the terminal gets taken over by the program's output. You should try to fix that, since it's not expected for a program to do that.

To read the program output for a docker container, you can use:

    docker logs swingmusic

Or the name of any other container you want.

To remove the container and the image, first stop it, then remove them both:

    docker stop swingmusic
    docker rm swingmusic # this removes the container
    docker image rm swingmusic # and this the image

Do ask if you have any other questions. You can then see if you can submit this to Dockerhub, or Quay, or some other public docker image repository.